### PR TITLE
Implement configuration file handling

### DIFF
--- a/tests/zpool_create/test_vdev_specs.py
+++ b/tests/zpool_create/test_vdev_specs.py
@@ -9,7 +9,7 @@ def _create_pool_tests(pool_name, pool_type, vdev_spec):
 
 def test_whole_disks():
     pool_types = ['', 'mirror', 'raidz', 'raidz1', 'raidz2']
-    disk_list = disk.find_free_disks()
+    disk_list = disk.disk_list()
 
     for pool_type in pool_types:
         _create_pool_tests('testpool', pool_type, disk_list)

--- a/zfstest/config.py
+++ b/zfstest/config.py
@@ -1,0 +1,64 @@
+import ConfigParser
+import os
+
+# anticipated sources of configuration information:
+#  (highest priority) command line arguments
+#                     user config file (via cmd line or /etc/zfstest.ini)
+#  (lowest priority)  default configuration in this project
+
+config_filename='zfs-test.cfg'
+config_section = 'ZFS-test'
+config_list_prefix = 'list:'
+configuration_description = {
+	'test_disks'	: config_list_prefix + ' disks used for DESTRUCTIVE testing, comma delimited',
+	'test_duration'	: '"short" or "long", determines subset of tests executed'
+}
+
+def comma_delim_list(in_string):
+	tmp = []
+	for item in in_string.split(','):
+		tmp.append(item)
+	return tmp
+
+def load_config_file(config_file, config_dict):
+	try:
+		f = open(config_file)
+		f.close()
+	except IOError as (errno,strerr):
+		return
+
+	config_from_file = ConfigParser.RawConfigParser()
+	config_from_file.read(config_file)
+
+	# record values for keys defined above
+	# replace any existing value for keys specified
+	for key in configuration_description.keys():
+		try:
+			value = config_from_file.get(config_section,key)
+		except ConfigParser.NoOptionError:
+			pass
+		else:
+			if configuration_description[key].startswith(config_list_prefix):
+				config_dict[key] = comma_delim_list(value)
+			else:
+				config_dict[key] = value
+
+def load_config():
+	configuration = {}
+	path_to_this_module_file = os.path.dirname(os.path.realpath(__file__)) + "/"
+
+	load_config_file(path_to_this_module_file + config_filename, configuration)
+	load_config_file('/etc/' + config_filename, configuration)
+	# config specified via cli options to be processed here
+
+	return configuration
+
+def print_config(config_dict):
+	for key in config_dict.keys():
+		if isinstance(config_dict[key], list):
+			print key + " => " + ','.join(config_dict[key])
+		else:
+			print key + " => " + config_dict[key]
+
+#test_config = load_config()
+#print_config(test_config)

--- a/zfstest/disk.py
+++ b/zfstest/disk.py
@@ -1,4 +1,5 @@
 import platform
+from zfstest.config import *
 
 platform_name = platform.system()
 if platform_name == 'SunOS':
@@ -8,3 +9,11 @@ elif platform_name == 'Linux':
 
 def foo():
     print 'hi'
+
+# the config file is loaded and queried here
+# until we have a session initialization method
+# somewhere.  Then we can load the config there
+# and just fetch the relevant value here
+def disk_list():
+    cfg = load_config()
+    return cfg['test_disks']

--- a/zfstest/zfs-test.cfg
+++ b/zfstest/zfs-test.cfg
@@ -1,0 +1,8 @@
+###
+# The zfs-test.cfg file in-tree provides default values
+#
+# A file by that name, /etc/ should be used to replace
+# these defaults with appropriate values for the local
+# system
+[ZFS-test]
+test_duration=short


### PR DESCRIPTION
Implemented a configuration file handler.

load_config() is currently called from within disk.py because we don't have a mechanism, yet, for session initialization.

The module is designed to look in more than one place for a config file.  It should be easy to modify it to look in a new location based on a command line option, or to modify an individual configuration value based on a command line option.

There is a little work that should still be done:
 - there is no attempt to warn the user if a file has invalid entries.  This would be good for catching typos.
 - if a required configuration value is not provided in any of the configuration files provided, the error message is not as helpful as it should be.
 - there is 'help' type text in a dictionary which is currently never exposed to the user, reducing its helpfulness.

I'm happy to take suggestions.